### PR TITLE
WIN-166 : 와인 뱃지 상세조회 API

### DIFF
--- a/Winey-API/src/main/java/com/example/wineyapi/user/service/UserServiceImpl.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/user/service/UserServiceImpl.java
@@ -43,6 +43,7 @@ import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -250,7 +251,7 @@ public class UserServiceImpl implements UserService {
     public User getCurrentLoggedInUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || !authentication.isAuthenticated()) {
+        if (authentication == null || !authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken) {
             return null;
         }
 

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/controller/WineBadgeController.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/controller/WineBadgeController.java
@@ -37,10 +37,12 @@ public class WineBadgeController {
 
     @Operation(summary = "06-02 WineBadge🪙 마이페이지 WINEY 배지 상세 조회 Made By Peter", description = "와이니 뱃지를 상세 조회하는 API입니다.")
     @GetMapping("/users/{userId}/wine-badges/{wineBadgeId}")
+    @CheckIdExistence @CheckOwnAccount
     public CommonResponse<WineBadgeResponse.BadgeDTO> getWineBadge(@PathVariable Long userId,
                                                                    @PathVariable Long wineBadgeId,
                                                                    @Parameter(hidden = true) @AuthenticationPrincipal User user) {
-        return null;
+        UserWineBadge userWineBadge = wineBadgeService.getWineBadgeById(wineBadgeId);
+        return CommonResponse.onSuccess(WineBadgeConvertor.toBadgeDTO(userWineBadge));
     }
 
 }

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/controller/WineBadgeController.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/controller/WineBadgeController.java
@@ -26,12 +26,21 @@ public class WineBadgeController {
 
     private final WineBadgeService wineBadgeService;
 
-    @Operation(summary = "06-01 WineBadge🪙 마이페이지 WINEY 배지 목록 조회 #FRAME Made By Peter", description = "본인의 와이니 (소믈리에 | 활동)뱃지 목록을 조회하는 API입니다.")
+    @Operation(summary = "06-01 WineBadge🪙 마이페이지 WINEY 배지 목록 조회 Made By Peter", description = "본인의 와이니 (소믈리에 | 활동)뱃지 목록을 조회하는 API입니다.")
     @GetMapping("/users/{userId}/wine-badges")
     @CheckIdExistence @CheckOwnAccount
-    public CommonResponse<WineBadgeResponse.WineBadgeListDTO> getWineBadge(@PathVariable Long userId,
+    public CommonResponse<WineBadgeResponse.WineBadgeListDTO> getWineBadgeList(@PathVariable Long userId,
                                                                            @Parameter(hidden = true) @AuthenticationPrincipal User user) {
         List<UserWineBadge> userWineBadgeList = wineBadgeService.getWineBadgeListByUser(userId);
         return CommonResponse.onSuccess(WineBadgeConvertor.toWineBadgeListDTO(userWineBadgeList));
     }
+
+    @Operation(summary = "06-02 WineBadge🪙 마이페이지 WINEY 배지 상세 조회 Made By Peter", description = "와이니 뱃지를 상세 조회하는 API입니다.")
+    @GetMapping("/users/{userId}/wine-badges/{wineBadgeId}")
+    public CommonResponse<WineBadgeResponse.BadgeDTO> getWineBadge(@PathVariable Long userId,
+                                                                   @PathVariable Long wineBadgeId,
+                                                                   @Parameter(hidden = true) @AuthenticationPrincipal User user) {
+        return null;
+    }
+
 }

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/convertor/WineBadgeConvertor.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/convertor/WineBadgeConvertor.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 @Component
 public class WineBadgeConvertor {
 
-    private static WineBadgeResponse.BadgeDTO toBadgeDTO(UserWineBadge userWineBadge) {
+    public static WineBadgeResponse.BadgeDTO toBadgeDTO(UserWineBadge userWineBadge) {
         return WineBadgeResponse.BadgeDTO.builder()
                 .badgeId(userWineBadge.getId())
                 .badgeType(userWineBadge.getBadge().getType())
@@ -38,7 +38,6 @@ public class WineBadgeConvertor {
                 .activitybadgeDTOList(activityBadgeList)
                 .build();
     }
-
 
     public UserWineBadge WineBadge(Badge badge, User user) {
         return UserWineBadge

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/convertor/WineBadgeConvertor.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/convertor/WineBadgeConvertor.java
@@ -19,6 +19,7 @@ public class WineBadgeConvertor {
                 .name(userWineBadge.getBadge().getBadgeName())
                 .description(userWineBadge.getBadge().getBadgeDescription())
                 .acquiredAt(userWineBadge.getCreatedAt())
+                .isRead(userWineBadge.getIsRead())
                 .build();
     }
 

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/dto/WineBadgeResponse.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/dto/WineBadgeResponse.java
@@ -24,6 +24,7 @@ public class WineBadgeResponse {
         private String description;
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime acquiredAt;
+        // TODO : 읽음 여부 추가
     }
 
     @NoArgsConstructor

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/dto/WineBadgeResponse.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/dto/WineBadgeResponse.java
@@ -24,7 +24,7 @@ public class WineBadgeResponse {
         private String description;
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime acquiredAt;
-        // TODO : 읽음 여부 추가
+        private Boolean isRead;
     }
 
     @NoArgsConstructor

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeService.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeService.java
@@ -13,4 +13,6 @@ public interface WineBadgeService {
     void checkActivityBadge(User user);
 
     List<UserWineBadge> getWineBadgeListByUser(Long userId);
+
+    UserWineBadge getWineBadgeById(Long wineBadgeId);
 }

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeServiceImpl.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeServiceImpl.java
@@ -245,9 +245,13 @@ public class WineBadgeServiceImpl implements WineBadgeService {
         return userWineBadgeRepository.findByUser_Id(userId);
     }
 
+    @Transactional
     @Override
     public UserWineBadge getWineBadgeById(Long wineBadgeId) {
-        return userWineBadgeRepository.findById(wineBadgeId)
+        UserWineBadge wineBadge = userWineBadgeRepository.findById(wineBadgeId)
                 .orElseThrow(() -> new NotFoundException(CommonResponseStatus.BADGE_NOT_FOUND));
+
+        wineBadge.setIsRead(Boolean.TRUE);
+        return wineBadge;
     }
 }

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeServiceImpl.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeServiceImpl.java
@@ -11,6 +11,7 @@ import com.example.wineycommon.exception.NotFoundException;
 import com.example.wineycommon.exception.errorcode.CommonResponseStatus;
 import com.example.wineydomain.badge.entity.Badge;
 import com.example.wineydomain.badge.entity.UserWineBadge;
+import com.example.wineydomain.badge.exception.WineBadgeErrorCode;
 import com.example.wineydomain.badge.repository.UserWineBadgeRepository;
 import com.example.wineydomain.tastingNote.entity.TastingNote;
 import com.example.wineydomain.tastingNote.repository.TastingNoteRepository;
@@ -249,7 +250,7 @@ public class WineBadgeServiceImpl implements WineBadgeService {
     @Override
     public UserWineBadge getWineBadgeById(Long wineBadgeId) {
         UserWineBadge wineBadge = userWineBadgeRepository.findById(wineBadgeId)
-                .orElseThrow(() -> new NotFoundException(CommonResponseStatus.BADGE_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(WineBadgeErrorCode.BADGE_NOT_FOUND));
 
         wineBadge.setIsRead(Boolean.TRUE);
         return wineBadge;

--- a/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeServiceImpl.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/wineBadge/service/WineBadgeServiceImpl.java
@@ -7,6 +7,8 @@ import com.example.wineyapi.notification.service.NotificationServiceImpl;
 import com.example.wineyapi.user.converter.UserConnectionConverter;
 import com.example.wineyapi.wineBadge.convertor.WineBadgeConvertor;
 import com.example.wineycommon.annotation.RedissonLock;
+import com.example.wineycommon.exception.NotFoundException;
+import com.example.wineycommon.exception.errorcode.CommonResponseStatus;
 import com.example.wineydomain.badge.entity.Badge;
 import com.example.wineydomain.badge.entity.UserWineBadge;
 import com.example.wineydomain.badge.repository.UserWineBadgeRepository;
@@ -241,5 +243,11 @@ public class WineBadgeServiceImpl implements WineBadgeService {
     @Override
     public List<UserWineBadge> getWineBadgeListByUser(Long userId) {
         return userWineBadgeRepository.findByUser_Id(userId);
+    }
+
+    @Override
+    public UserWineBadge getWineBadgeById(Long wineBadgeId) {
+        return userWineBadgeRepository.findById(wineBadgeId)
+                .orElseThrow(() -> new NotFoundException(CommonResponseStatus.BADGE_NOT_FOUND));
     }
 }

--- a/Winey-Common/src/main/java/com/example/wineycommon/exception/errorcode/CommonResponseStatus.java
+++ b/Winey-Common/src/main/java/com/example/wineycommon/exception/errorcode/CommonResponseStatus.java
@@ -89,12 +89,7 @@ public enum CommonResponseStatus implements BaseErrorCode {
     MESSAGE_SEND_FAILED(BAD_REQUEST, "M001", "메시지 전송이 실패했습니다. 올바른 번호인지 확인하세요."),
     MESSAGE_NOT_FOUND(NOT_FOUND, "M002", "인증번호 전송 기록이 존재하지 않습니다."),
     MESSAGE_VERIFICATION_TIMEOUT(BAD_REQUEST, "M003","인증 번호가 만료되었습니다."),
-    VERIFICATION_DID_NOT_MATCH(BAD_REQUEST, "M004", "인증 번호가 일치하지 않습니다."),
-
-    /**
-     * BXXX : Badge 관련 에러
-     */
-    BADGE_NOT_FOUND(NOT_FOUND, "B001", "존재하지 않는 뱃지입니다.");
+    VERIFICATION_DID_NOT_MATCH(BAD_REQUEST, "M004", "인증 번호가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/Winey-Common/src/main/java/com/example/wineycommon/exception/errorcode/CommonResponseStatus.java
+++ b/Winey-Common/src/main/java/com/example/wineycommon/exception/errorcode/CommonResponseStatus.java
@@ -89,9 +89,12 @@ public enum CommonResponseStatus implements BaseErrorCode {
     MESSAGE_SEND_FAILED(BAD_REQUEST, "M001", "메시지 전송이 실패했습니다. 올바른 번호인지 확인하세요."),
     MESSAGE_NOT_FOUND(NOT_FOUND, "M002", "인증번호 전송 기록이 존재하지 않습니다."),
     MESSAGE_VERIFICATION_TIMEOUT(BAD_REQUEST, "M003","인증 번호가 만료되었습니다."),
-    VERIFICATION_DID_NOT_MATCH(BAD_REQUEST, "M004", "인증 번호가 일치하지 않습니다.");
+    VERIFICATION_DID_NOT_MATCH(BAD_REQUEST, "M004", "인증 번호가 일치하지 않습니다."),
 
-
+    /**
+     * BXXX : Badge 관련 에러
+     */
+    BADGE_NOT_FOUND(NOT_FOUND, "B001", "존재하지 않는 뱃지입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/Winey-Domain/src/main/generated/com/example/wineydomain/badge/entity/QUserWineBadge.java
+++ b/Winey-Domain/src/main/generated/com/example/wineydomain/badge/entity/QUserWineBadge.java
@@ -31,6 +31,8 @@ public class QUserWineBadge extends EntityPathBase<UserWineBadge> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final BooleanPath isRead = createBoolean("isRead");
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 

--- a/Winey-Domain/src/main/java/com/example/wineydomain/badge/entity/UserWineBadge.java
+++ b/Winey-Domain/src/main/java/com/example/wineydomain/badge/entity/UserWineBadge.java
@@ -33,4 +33,7 @@ public class UserWineBadge extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Badge badge;
+
+    @Builder.Default
+    private Boolean isRead = Boolean.FALSE;
 }

--- a/Winey-Domain/src/main/java/com/example/wineydomain/badge/exception/WineBadgeErrorCode.java
+++ b/Winey-Domain/src/main/java/com/example/wineydomain/badge/exception/WineBadgeErrorCode.java
@@ -1,0 +1,45 @@
+package com.example.wineydomain.badge.exception;
+
+import com.example.wineycommon.annotation.ExplainError;
+import com.example.wineycommon.exception.errorcode.BaseErrorCode;
+import com.example.wineycommon.exception.errorcode.ErrorReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum WineBadgeErrorCode implements BaseErrorCode {
+    /**
+     * BXXX : Badge 관련 에러
+     */
+    BADGE_NOT_FOUND(NOT_FOUND, "B001", "존재하지 않는 뱃지입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReason getErrorReason() {
+        return ErrorReason.builder().message(message).code(code).isSuccess(false).build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getMessage();
+    }
+
+    @Override
+    public ErrorReason getErrorReasonHttpStatus(){
+        return ErrorReason.builder().message(message).code(code).isSuccess(false).httpStatus(httpStatus).build();
+    }
+}


### PR DESCRIPTION
## 개요
와인 뱃지 상세 조회 API와 읽음 처리를 구현했습니다.

## 변경로직
- Problem) 기존 AOP로 동일 유저임을 검증했던 CheckOwnAccountAspect에서 간헐적으로 에러가 터져서 확인해본 결과, Jwt 필터에서 사용자가 없는 경우 인증객체로 Null이 아닌 AnonymousAuthenticationToken을 세팅해주고있었습니다.
- Solution) 우선은 임시로 익명 인증 토큰인지를 체크해서 해결해두었는데, 실제 익명 사용자 정책 등의 확장을 고려할 때 좋은 방법은 아니라서 나중에 고민해보고 리팩토링하겠습니다!