### PR TITLE
fix: FCM 토큰 삭제 로직 추가 in 회원 탈퇴

### DIFF
--- a/Winey-API/src/main/java/com/example/wineyapi/user/service/UserServiceImpl.java
+++ b/Winey-API/src/main/java/com/example/wineyapi/user/service/UserServiceImpl.java
@@ -139,6 +139,13 @@ public class UserServiceImpl implements UserService {
                 .collect(Collectors.toList());
         recommendWineRepository.deleteAllByIdInBatch(recommendWineIds);
 
+        // FCM 토큰 삭제
+        List<UserFcmToken> userFcmTokenList = userFcmTokenRepository.findByUser(user);
+        List<Long> userFcmTokenIds = userFcmTokenList.stream()
+                .map(UserFcmToken::getId)
+                .collect(Collectors.toList());
+        userFcmTokenRepository.deleteAllByIdInBatch(userFcmTokenIds);
+
         // 탈퇴 히스토리 테이블에 탈퇴 정보 기록
         userExitHistoryRepository.save(UserExitHistory.from(user, reason));
 

--- a/Winey-Domain/src/main/java/com/example/wineydomain/user/repository/UserFcmTokenRepository.java
+++ b/Winey-Domain/src/main/java/com/example/wineydomain/user/repository/UserFcmTokenRepository.java
@@ -4,6 +4,10 @@ import com.example.wineydomain.user.entity.User;
 import com.example.wineydomain.user.entity.UserFcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
     void deleteByUserAndDeviceId(User user, String deviceId);
+
+    List<UserFcmToken> findByUser(User user);
 }


### PR DESCRIPTION
## 개요
새로 추가된 UserFCMToken 연관관계도 끊고 같이 지워줌으로써 회원 탈퇴 500에러를 해결했습니다.